### PR TITLE
added CapSolver feature Anchor/Reload

### DIFF
--- a/CaptchaSharp/CaptchaSharp.xml
+++ b/CaptchaSharp/CaptchaSharp.xml
@@ -968,6 +968,18 @@
         <member name="F:CaptchaSharp.Services.CapSolverService.appId">
             <summary>The ID of the app.</summary>
         </member>
+        <member name="P:CaptchaSharp.Services.CapSolverService.Anchor">
+            <summary>
+            Used by CapSolver to increase quality of Google ReCaptcha
+            https://www.capsolver.com/blog/reCAPTCHA/How-to-bypass-all-the-versions-reCAPTCHA-v2-v3
+            </summary>
+        </member>
+        <member name="P:CaptchaSharp.Services.CapSolverService.Reload">
+            <summary>
+            Used by CapSolver to increase quality of Google ReCaptcha
+            https://www.capsolver.com/blog/reCAPTCHA/How-to-bypass-all-the-versions-reCAPTCHA-v2-v3
+            </summary>
+        </member>
         <member name="M:CaptchaSharp.Services.CapSolverService.#ctor(System.String,System.Net.Http.HttpClient)">
             <summary>Initializes a <see cref="T:CaptchaSharp.Services.CapSolverService"/> using the given <paramref name="apiKey"/> and 
             <paramref name="httpClient"/>. If <paramref name="httpClient"/> is null, a default one will be created.</summary>

--- a/CaptchaSharp/CaptchaSharp.xml
+++ b/CaptchaSharp/CaptchaSharp.xml
@@ -1014,6 +1014,43 @@
         <member name="P:CaptchaSharp.Services.CapSolverService.Capabilities">
             <inheritdoc/>
         </member>
+        <member name="T:CaptchaSharp.Services.CheapCaptchaService">
+            <summary>The service provided by <c>https://www.deathbycaptcha.com/</c></summary>
+        </member>
+        <member name="P:CaptchaSharp.Services.CheapCaptchaService.Username">
+            <summary>Your DeathByCaptcha account name.</summary>
+        </member>
+        <member name="P:CaptchaSharp.Services.CheapCaptchaService.Password">
+            <summary>Your DeathByCaptcha account password.</summary>
+        </member>
+        <member name="F:CaptchaSharp.Services.CheapCaptchaService.httpClient">
+            <summary>The default <see cref="T:System.Net.Http.HttpClient"/> used for requests.</summary>
+        </member>
+        <member name="M:CaptchaSharp.Services.CheapCaptchaService.#ctor(System.String,System.String,System.Net.Http.HttpClient)">
+            <summary>Initializes a <see cref="T:CaptchaSharp.Services.DeathByCaptchaService"/> using the given account credentials and 
+            <paramref name="httpClient"/>. If <paramref name="httpClient"/> is null, a default one will be created.</summary>
+        </member>
+        <member name="M:CaptchaSharp.Services.CheapCaptchaService.GetBalanceAsync(System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:CaptchaSharp.Services.CheapCaptchaService.SolveImageCaptchaAsync(System.String,CaptchaSharp.Models.ImageCaptchaOptions,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:CaptchaSharp.Services.CheapCaptchaService.SolveRecaptchaV2Async(System.String,System.String,System.String,System.Boolean,System.Boolean,CaptchaSharp.Models.Proxy,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:CaptchaSharp.Services.CheapCaptchaService.SolveRecaptchaV3Async(System.String,System.String,System.String,System.Single,System.Boolean,CaptchaSharp.Models.Proxy,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:CaptchaSharp.Services.CheapCaptchaService.SolveFuncaptchaAsync(System.String,System.String,System.String,System.Boolean,CaptchaSharp.Models.Proxy,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:CaptchaSharp.Services.CheapCaptchaService.CheckResult(CaptchaSharp.Models.CaptchaTask,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:CaptchaSharp.Services.CheapCaptchaService.ReportSolution(System.Int64,CaptchaSharp.Enums.CaptchaType,System.Boolean,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
         <member name="T:CaptchaSharp.Services.CustomAntiCaptchaService">
             <summary>The service provided by a service that implements the anti-captcha API.</summary>
         </member>

--- a/CaptchaSharp/Models/Proxy.cs
+++ b/CaptchaSharp/Models/Proxy.cs
@@ -45,5 +45,7 @@ namespace CaptchaSharp.Models
 
         internal string GetCookieString()
             => Cookies != null ? string.Join("; ", Cookies.Select(c => $"{c.Item1}={c.Item2}")) : string.Empty;
+
+      
     }
 }

--- a/CaptchaSharp/Services/CapSolver/Requests/Tasks/CapSolverTaskProxyless.cs
+++ b/CaptchaSharp/Services/CapSolver/Requests/Tasks/CapSolverTaskProxyless.cs
@@ -2,6 +2,8 @@
 {
     internal class CapSolverTaskProxyless
     {
+        public string Anchor { get; set; }
+        public string Reload { get; set; }
         public string Type { get; set; }
     }
 }

--- a/CaptchaSharp/Services/CapSolver/Requests/Tasks/Proxied/CapSolverTask.cs
+++ b/CaptchaSharp/Services/CapSolver/Requests/Tasks/Proxied/CapSolverTask.cs
@@ -14,7 +14,8 @@ namespace CaptchaSharp.Services.CapSolver.Requests.Tasks.Proxied
         public string ProxyPassword { get; set; }
         public string UserAgent { get; set; }
         public string Cookies { get; set; } // Format cookiename1=cookievalue1; cookiename2=cookievalue2
-
+        public string Anchor { get; set; }
+        public string Reload { get; set; }
         public CapSolverTask SetProxy(Proxy proxy)
         {
             if (!System.Net.IPAddress.TryParse(proxy.Host, out _))
@@ -27,7 +28,6 @@ namespace CaptchaSharp.Services.CapSolver.Requests.Tasks.Proxied
             ProxyPassword = proxy.Password;
             UserAgent = proxy.UserAgent;
             SetCookies(proxy.Cookies);
-
             return this;
         }
 

--- a/CaptchaSharp/Services/CapSolverService.cs
+++ b/CaptchaSharp/Services/CapSolverService.cs
@@ -26,6 +26,18 @@ namespace CaptchaSharp.Services
         /// <summary>The ID of the app.</summary>
         private readonly string appId = "FE552FC0-8A06-4B44-BD30-5B9DDA2A4194";
 
+        /// <summary>
+        /// Used by CapSolver to increase quality of Google ReCaptcha
+        /// https://www.capsolver.com/blog/reCAPTCHA/How-to-bypass-all-the-versions-reCAPTCHA-v2-v3
+        /// </summary>
+        public string Anchor { get; set; }
+
+        /// <summary>
+        /// Used by CapSolver to increase quality of Google ReCaptcha
+        /// https://www.capsolver.com/blog/reCAPTCHA/How-to-bypass-all-the-versions-reCAPTCHA-v2-v3
+        /// </summary>
+        public string Reload { get; set; }
+
         /// <summary>Initializes a <see cref="CapSolverService"/> using the given <paramref name="apiKey"/> and 
         /// <paramref name="httpClient"/>. If <paramref name="httpClient"/> is null, a default one will be created.</summary>
         public CapSolverService(string apiKey, HttpClient httpClient = null)
@@ -165,7 +177,9 @@ namespace CaptchaSharp.Services
                     WebsiteURL = siteUrl,
                     PageAction = action,
                     MinScore = minScore,
-                    IsEnterprise = enterprise
+                    IsEnterprise = enterprise,
+                    Anchor = Anchor,
+                    Reload = Reload
                 };
             }
             else
@@ -176,7 +190,9 @@ namespace CaptchaSharp.Services
                     WebsiteURL = siteUrl,
                     PageAction = action,
                     MinScore = minScore,
-                    IsEnterprise = enterprise
+                    IsEnterprise = enterprise,
+                    Anchor = Anchor,
+                    Reload = Reload
                 }.SetProxy(proxy);
             }
 

--- a/CaptchaSharp/Services/CheapCaptchaService.cs
+++ b/CaptchaSharp/Services/CheapCaptchaService.cs
@@ -1,0 +1,273 @@
+﻿using CaptchaSharp.Enums;
+using CaptchaSharp.Exceptions;
+using CaptchaSharp.Models;
+using CaptchaSharp.Services.DeathByCaptcha.Tasks;
+using CaptchaSharp.Services.DeathByCaptcha.Tasks.Proxied;
+using System;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace CaptchaSharp.Services
+{
+    /// <summary>The service provided by <c>https://www.deathbycaptcha.com/</c></summary>
+    public class CheapCaptchaService : CaptchaService
+    {
+        /// <summary>Your DeathByCaptcha account name.</summary>
+        public string Username { get; set; }
+
+        /// <summary>Your DeathByCaptcha account password.</summary>
+        public string Password { get; set; }
+
+        /// <summary>The default <see cref="HttpClient"/> used for requests.</summary>
+        protected HttpClient httpClient;
+
+        /*
+         * Sometimes the DBC API randomly replies with query strings even when json is requested, so
+         * we will avoid using the Accept: application/json header.
+         */
+
+        /// <summary>Initializes a <see cref="DeathByCaptchaService"/> using the given account credentials and 
+        /// <paramref name="httpClient"/>. If <paramref name="httpClient"/> is null, a default one will be created.</summary>
+        public CheapCaptchaService(string username, string password, HttpClient httpClient = null)
+        {
+            Username = username;
+            Password = password;
+            this.httpClient = httpClient ?? new HttpClient();
+            this.httpClient.BaseAddress = new Uri("http://api.cheapcaptcha.com/api/");
+        }
+
+        #region Getting the Balance
+        /// <inheritdoc/>
+        public async override Task<decimal> GetBalanceAsync(CancellationToken cancellationToken = default)
+        {
+            var response = await httpClient.PostAsync(
+                "user",
+                GetAuthPair(),
+                cancellationToken)
+                .ConfigureAwait(false);
+
+            var query = HttpUtility.ParseQueryString(await DecodeIsoResponse(response));
+
+            if (IsError(query))
+                throw new BadAuthenticationException(GetErrorMessage(query));
+
+            // The server returns the balance in cents
+            return decimal.Parse(query["balance"], CultureInfo.InvariantCulture) / 100;
+        }
+        #endregion
+
+        #region Solve Methods
+        /// <inheritdoc/>
+        public async override Task<StringResponse> SolveImageCaptchaAsync
+            (string base64, ImageCaptchaOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var response = await httpClient.PostAsync
+                ("captcha",
+                GetAuthPair()
+                    .Add("captchafile", $"base64:{base64}")
+                    .ToMultipartFormDataContent(),
+                cancellationToken);
+
+            return await TryGetResult(HttpUtility.ParseQueryString(await DecodeIsoResponse(response)),
+                CaptchaType.ImageCaptcha, cancellationToken) as StringResponse;
+        }
+
+        /// <inheritdoc/>
+        public async override Task<StringResponse> SolveRecaptchaV2Async
+            (string siteKey, string siteUrl, string dataS = "", bool enterprise = false, bool invisible = false,
+            Proxy proxy = null, CancellationToken cancellationToken = default)
+        {
+            DBCTaskProxyless task;
+
+            if (proxy != null)
+            {
+                task = new RecaptchaV2Task
+                {
+                    GoogleKey = siteKey,
+                    PageUrl = siteUrl
+                }.SetProxy(proxy);
+            }
+            else
+            {
+                task = new RecaptchaV2TaskProxyless
+                {
+                    GoogleKey = siteKey,
+                    PageUrl = siteUrl
+                };
+            }
+
+            var response = await httpClient.PostAsync(
+                "captcha",
+                GetAuthPair()
+                    .Add("type", 4)
+                    .Add("token_params", task.SerializeLowerCase()),
+                cancellationToken)
+                .ConfigureAwait(false);
+
+            return await TryGetResult(HttpUtility.ParseQueryString(await DecodeIsoResponse(response)),
+                CaptchaType.ReCaptchaV2, cancellationToken) as StringResponse;
+        }
+
+        /// <inheritdoc/>
+        public async override Task<StringResponse> SolveRecaptchaV3Async
+            (string siteKey, string siteUrl, string action = "verify", float minScore = 0.4F, bool enterprise = false,
+            Proxy proxy = null, CancellationToken cancellationToken = default)
+        {
+            DBCTaskProxyless task;
+
+            if (proxy != null)
+            {
+                task = new RecaptchaV3Task
+                {
+                    GoogleKey = siteKey,
+                    PageUrl = siteUrl,
+                    Action = action,
+                    Min_Score = minScore
+                }.SetProxy(proxy);
+            }
+            else
+            {
+                task = new RecaptchaV3TaskProxyless
+                {
+                    GoogleKey = siteKey,
+                    PageUrl = siteUrl,
+                    Action = action,
+                    Min_Score = minScore
+                };
+            }
+
+            var response = await httpClient.PostAsync(
+                "captcha",
+                GetAuthPair()
+                    .Add("type", 5)
+                    .Add("token_params", task.SerializeLowerCase()),
+                cancellationToken)
+                .ConfigureAwait(false);
+
+            return await TryGetResult(HttpUtility.ParseQueryString(await DecodeIsoResponse(response)),
+                CaptchaType.ReCaptchaV3, cancellationToken) as StringResponse;
+        }
+
+        /// <inheritdoc/>
+        public async override Task<StringResponse> SolveFuncaptchaAsync
+            (string publicKey, string serviceUrl, string siteUrl, bool noJS = false, Proxy proxy = null,
+            CancellationToken cancellationToken = default)
+        {
+            DBCTaskProxyless task;
+
+            if (proxy != null)
+            {
+                task = new FuncaptchaTask
+                {
+                    PublicKey = publicKey,
+                    PageUrl = siteUrl
+                }.SetProxy(proxy);
+            }
+            else
+            {
+                task = new FuncaptchaTaskProxyless
+                {
+                    PublicKey = publicKey,
+                    PageUrl = siteUrl
+                };
+            }
+
+            var response = await httpClient.PostAsync(
+                "captcha",
+                GetAuthPair()
+                    .Add("type", 6)
+                    .Add("funcaptcha_params", task.SerializeLowerCase()),
+                cancellationToken)
+                .ConfigureAwait(false);
+
+            return await TryGetResult(HttpUtility.ParseQueryString(await DecodeIsoResponse(response)),
+                CaptchaType.FunCaptcha, cancellationToken) as StringResponse;
+        }
+        #endregion
+
+        #region Getting the result
+        private async Task<CaptchaResponse> TryGetResult
+            (NameValueCollection response, CaptchaType type, CancellationToken cancellationToken = default)
+        {
+            if (IsError(response))
+                throw new TaskCreationException(GetErrorMessage(response));
+
+            var task = new CaptchaTask(response["captcha"], type);
+
+            return await TryGetResult(task, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected async override Task<CaptchaResponse> CheckResult(CaptchaTask task, CancellationToken cancellationToken = default)
+        {
+            var response = await httpClient.GetAsync($"captcha/{task.Id}", cancellationToken);
+            var query = HttpUtility.ParseQueryString(await DecodeIsoResponse(response));
+
+            if (query["text"] == string.Empty)
+                return default;
+
+            task.Completed = true;
+
+            if (IsError(query) || query["is_correct"] == "0")
+                throw new TaskSolutionException(GetErrorMessage(query));
+
+            return new StringResponse() { Id = task.Id, Response = query["text"] };
+        }
+        #endregion
+
+        #region Reporting the solution
+        /// <inheritdoc/>
+        public async override Task ReportSolution
+            (long id, CaptchaType type, bool correct = false, CancellationToken cancellationToken = default)
+        {
+            if (correct)
+                throw new NotSupportedException("This service doesn't allow reporting of good solutions");
+
+            var response = await httpClient.PostAsync(
+                $"captcha/{id}/report",
+                GetAuthPair(),
+                cancellationToken)
+                .ConfigureAwait(false);
+
+            var query = HttpUtility.ParseQueryString(await DecodeIsoResponse(response));
+
+            if (IsError(query))
+                throw new TaskReportException(GetErrorMessage(query));
+        }
+        #endregion
+
+        #region Private Methods
+        private async Task<string> DecodeIsoResponse(HttpResponseMessage response)
+        {
+            using (var sr = new StreamReader(
+                await response.Content.ReadAsStreamAsync(), Encoding.GetEncoding("iso-8859-1")))
+            {
+                return sr.ReadToEnd();
+            }
+        }
+
+        private StringPairCollection GetAuthPair()
+        {
+            return new StringPairCollection()
+                    .Add("username", Username)
+                    .Add("password", Password);
+        }
+
+        private bool IsError(NameValueCollection response)
+        {
+            return response["status"] == "255";
+        }
+
+        private string GetErrorMessage(NameValueCollection response)
+        {
+            return response["error"];
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
As per the documentation here: https://www.capsolver.com/blog/reCAPTCHA/How-to-bypass-all-the-versions-reCAPTCHA-v2-v3

Using the properties "Anchor" and "Reload" in the CapSolver Google reCAPTCHA v3 request increases the quality score of the solution. Tested and verified to provide a 2x increase in quality score (estimate)

Set as follows;

```
var captchaService = new CapSolverService("CAP-xxxxxx", null);
captchaService.Anchor = ....;
captchaService.Reload = ....;
```