### PR TITLE
Added support for Cloudflare Turnstile to 2Captcha

### DIFF
--- a/CaptchaSharp/CaptchaService.cs
+++ b/CaptchaSharp/CaptchaService.cs
@@ -388,6 +388,32 @@ namespace CaptchaSharp
         {
             throw new NotSupportedException();
         }
+        
+       /// <summary>Solves a Cloudflare Turnstile captcha.</summary>
+       /// 
+       /// <param name="siteKey">The site key, can be found in the webpage source or by sniffing requests.</param>
+       /// <param name="siteUrl">The URL where the captcha appears.</param>
+       /// <param name="proxy">
+       /// A proxy that can be used by the captcha service to fetch the captcha challenge from the same IP you are 
+       /// going to send it from when you submit the form. It can help bypass some blocks. If null, the service will 
+       /// fetch the captcha without using a proxy.
+       /// </param>
+       /// <param name="cancellationToken">A token that can be used to cancel the async task.</param>
+       /// 
+       /// <returns>
+       /// A <see cref="StringResponse"/> containing the captcha id to be used with 
+       /// <see cref="ReportSolution(long, CaptchaType, bool, CancellationToken)"/> and the 
+       /// captcha solution as plaintext.
+       /// </returns>
+       /// 
+       /// <exception cref="TaskCreationException"></exception>
+       /// <exception cref="TaskSolutionException"></exception>
+       /// <exception cref="TimeoutException"></exception>
+       public virtual Task<StringResponse> SolveTurnstileCaptchaAsync
+           (string siteKey, string siteUrl, Proxy proxy = null, CancellationToken cancellationToken = default)
+       {
+           throw new NotSupportedException();
+       }
 
         /// <summary>
         /// Reports a captcha solution as good or bad to the service.

--- a/CaptchaSharp/Enums/CaptchaType.cs
+++ b/CaptchaSharp/Enums/CaptchaType.cs
@@ -35,5 +35,8 @@ namespace CaptchaSharp.Enums
 
         /// <summary>A type of challenge based captcha.</summary>
         DataDome
+
+        /// <summary>The Cloudflare Turnstile captcha.</summary>
+        Turnstile
     }
 }

--- a/CaptchaSharp/Enums/CaptchaType.cs
+++ b/CaptchaSharp/Enums/CaptchaType.cs
@@ -34,7 +34,7 @@ namespace CaptchaSharp.Enums
         Capy,
 
         /// <summary>A type of challenge based captcha.</summary>
-        DataDome
+        DataDome,
 
         /// <summary>The Cloudflare Turnstile captcha.</summary>
         Turnstile

--- a/CaptchaSharp/Services/TwoCaptchaService.cs
+++ b/CaptchaSharp/Services/TwoCaptchaService.cs
@@ -313,7 +313,6 @@ namespace CaptchaSharp.Services
                 : await TryGetResult(response, CaptchaType.Capy, cancellationToken).ConfigureAwait(false)
                 ) as CapyResponse;
         }
-        #endregion
 
         /// <inheritdoc/>
         public async override Task<StringResponse> SolveTurnstileCaptchaAsync

--- a/CaptchaSharp/Services/TwoCaptchaService.cs
+++ b/CaptchaSharp/Services/TwoCaptchaService.cs
@@ -315,6 +315,32 @@ namespace CaptchaSharp.Services
         }
         #endregion
 
+        /// <inheritdoc/>
+        public async override Task<StringResponse> SolveTurnstileCaptchaAsync
+            (string siteKey, string siteUrl, Proxy proxy = null, CancellationToken cancellationToken = default)
+        {
+            var response = await httpClient.PostMultipartToStringAsync
+                ("in.php",
+                new StringPairCollection()
+                    .Add("key", ApiKey)
+                    .Add("method", "turnstile")
+                    .Add("sitekey", siteKey)
+                    .Add("pageurl", siteUrl)
+                    .Add("soft_id", softId)
+                    .Add("json", "1", UseJsonFlag)
+                    .Add("header_acao", "1", AddACAOHeader)
+                    .Add(ConvertProxy(proxy))
+                    .ToMultipartFormDataContent(),
+                cancellationToken)
+                .ConfigureAwait(false);
+
+            return (UseJsonFlag
+                ? await TryGetResult(response.Deserialize<Response>(), CaptchaType.Turnstile, cancellationToken).ConfigureAwait(false)
+                : await TryGetResult(response, CaptchaType.Turnstile, cancellationToken).ConfigureAwait(false)
+                ) as StringResponse;
+        }
+        #endregion
+        
         #region Getting the result
         internal async Task<CaptchaResponse> TryGetResult
             (Response response, CaptchaType type, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Added support for Cloudflare Turnstile to 2Captcha.
Here is a usage example that I used to test : 

```
using System;
using System.Net.Http;
using System.Text;
using System.Threading.Tasks;
using CaptchaSharp.Services;

public class Program
{
    private static readonly HttpClient httpClient = new HttpClient();

    public static async Task Main(string[] args)
    {
        string apiKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
        string siteKey = "0x4AAAAAAAVrOwQWPlm3Bnr5";
        string siteUrl = "https://2captcha.com/demo/cloudflare-turnstile";

        var twoCaptchaService = new TwoCaptchaService(apiKey);

        var response = await twoCaptchaService.SolveTurnstileCaptchaAsync(siteKey, siteUrl);
        // Console.WriteLine(response.Response);

        var verificationResponse = await VerifyCaptchaAsync(response.Response);

        Console.WriteLine($"Verification Response: {verificationResponse}");

    }

    private static async Task<string> VerifyCaptchaAsync(string captchaSolution)
    {
        var requestUrl = "https://2captcha.com/api/v1/captcha-demo/cloudflare-turnstile/verify";
        var requestData = $"{{\"response\":\"{captchaSolution}\"}}";

        var request = new HttpRequestMessage(HttpMethod.Post, requestUrl)
        {
            Content = new StringContent(requestData, Encoding.UTF8, "application/json")
        };

        request.Headers.Add("accept", "*/*");
        request.Headers.Add("accept-language", "fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7");
        request.Headers.Add("priority", "u=1, i");
        request.Headers.Add("referer", "https://2captcha.com/demo/cloudflare-turnstile");
        request.Headers.Add("user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36");

        var response = await httpClient.SendAsync(request);
        var responseBody = await response.Content.ReadAsStringAsync();

        return responseBody;
    }

}
```
